### PR TITLE
Automatically make queue listener subscribe to queue

### DIFF
--- a/lib/propono.rb
+++ b/lib/propono.rb
@@ -4,12 +4,12 @@ require 'propono/components/sns'
 require 'propono/components/sqs'
 require "propono/components/queue"
 require "propono/components/topic"
+require "propono/components/post_subscription"
+require "propono/components/queue_subscription"
 
-require "propono/services/post_subscriber"
 require "propono/services/publisher"
 require "propono/services/queue_creator"
 require "propono/services/queue_listener"
-require "propono/services/queue_subscriber"
 require "propono/services/subscriber"
 require "propono/services/topic_creator"
 

--- a/lib/propono/components/post_subscription.rb
+++ b/lib/propono/components/post_subscription.rb
@@ -1,9 +1,9 @@
 module Propono
-  class PostSubscriber
+  class PostSubscription
     include Sns
 
-    def self.subscribe(topic, endpoint)
-      new(topic, endpoint).subscribe
+    def self.create(topic, endpoint)
+      new(topic, endpoint).create
     end
 
     def initialize(topic_id, endpoint)
@@ -11,7 +11,7 @@ module Propono
       @endpoint = endpoint
     end
 
-    def subscribe
+    def create
       topic_arn = TopicCreator.find_or_create(@topic_id)
       sns.subscribe(topic_arn, @endpoint, 'http')
     end

--- a/lib/propono/components/queue_subscription.rb
+++ b/lib/propono/components/queue_subscription.rb
@@ -1,30 +1,32 @@
 module Propono
-  class QueueSubscriber
+  class QueueSubscription
 
     include Sns
     include Sqs
 
     attr_reader :topic_arn, :queue
 
-    def self.subscribe(topic_id)
-      new(topic_id).subscribe
+    def self.create(topic_id)
+      new(topic_id).tap do |subscription|
+        subscription.create
+      end
     end
 
     def initialize(topic_id)
       @topic_id = topic_id
     end
 
-    def subscribe
+    def create
       @topic = TopicCreator.find_or_create(@topic_id)
       @queue = QueueCreator.find_or_create(queue_name)
       sns.subscribe(@topic.arn, @queue.arn, 'sqs')
     end
 
-    private
-
     def queue_name
-      "#{config.application_name.gsub(" ", "_")}::#{@topic_id}"
+      @queue_name ||= "#{config.application_name.gsub(" ", "_")}::#{@topic_id}"
     end
+
+    private
 
     def config
       Configuration.instance

--- a/lib/propono/services/queue_listener.rb
+++ b/lib/propono/services/queue_listener.rb
@@ -3,43 +3,51 @@ module Propono
 
     include Sqs
 
-    def self.listen(queue_url, &block)
-      new(queue_url, &block).listen
+    def self.listen(topic_id, &message_processor)
+      new(topic_id, &message_processor).listen
     end
 
-    def initialize(queue_url, &block)
-      @queue_url = queue_url
-      @block = block
+    def initialize(topic_id, &message_processor)
+      @topic_id = topic_id
+      @message_processor = message_processor
     end
 
     def listen
-      loop {
-        sleep 10 unless read_messages
-      }
+      loop do
+        unless read_messages
+          sleep 10
+        end
+      end
     end
 
     private
 
     def read_messages
-      begin
-        response = sqs.receive_message( @queue_url, options = { 'MaxNumberOfMessages' => 10 } )
-        messages = response.body['Message']
-        if messages.empty?
-          false
-        else
-          process_messages(messages)
-        end
-      rescue
-        config.logger.puts "Unexpected error reading from queue #{@queue_url}"
+      response = sqs.receive_message( queue_url, options = { 'MaxNumberOfMessages' => 10 } )
+      messages = response.body['Message']
+      if messages.empty?
+        false
+      else
+        process_messages(messages)
       end
+    rescue
+      config.logger.puts "Unexpected error reading from queue #{queue_url}"
     end
 
     def process_messages(messages)
       messages.each do |message|
-        @block.call(message)
+        @message_processor.call(message)
         sqs.delete_message(message['ReceiptHandle'])
       end
       true
+    end
+
+    def queue_url
+      @queue_url ||= subscription.queue.url
+    end
+
+    def subscription
+      @subscription ||= QueueSubscription.create(@topic_id)
     end
   end
 end

--- a/lib/propono/services/subscriber.rb
+++ b/lib/propono/services/subscriber.rb
@@ -2,11 +2,11 @@ module Propono
 
   module Subscriber
     def self.subscribe_by_queue(topic)
-      QueueSubscriber.subscribe(topic)
+      QueueSubscription.create(topic)
     end
 
     def self.subscribe_by_post(topic, endpoint)
-      PostSubscriber.subscribe(topic, endpoint)
+      PostSubscription.create(topic, endpoint)
     end
   end
 end

--- a/test/post_subscription_test.rb
+++ b/test/post_subscription_test.rb
@@ -1,14 +1,14 @@
 require File.expand_path('../test_helper', __FILE__)
 
 module Propono
-  class PostSubscriberTest < Minitest::Test
+  class PostSubscriptionTest < Minitest::Test
     def test_create_topic
       topic = 'foobar'
       TopicCreator.expects(:find_or_create).with(topic)
-      PostSubscriber.subscribe(topic, "foobar")
+      PostSubscription.create(topic, "foobar")
     end
 
-    def test_subscribe_calls_subscribe
+    def test_create_calls_create
       arn = "arn123"
       endpoint = "http://meducation.net/some_queue_name"
 
@@ -16,9 +16,9 @@ module Propono
 
       sns = mock()
       sns.expects(:subscribe).with(arn, endpoint, 'http')
-      subscriber = PostSubscriber.new("Some topic", endpoint)
-      subscriber.stubs(sns: sns)
-      subscriber.subscribe
+      subscription = PostSubscription.new("Some topic", endpoint)
+      subscription.stubs(sns: sns)
+      subscription.create
     end
 
     def test_it_correctly_uses_http_and_https

--- a/test/queue_listener_test.rb
+++ b/test/queue_listener_test.rb
@@ -4,10 +4,11 @@ module Propono
   class QueueListenerTest < Minitest::Test
 
     def setup
-      @queue_url = "http://example.com"
+      super
+      @topic_id = "some-topic"
 
-      @receipt_hanlde1 = "test-receipt-handle1"
-      @receipt_hanlde2 = "test-receipt-handle2"
+      @receipt_handle1 = "test-receipt-handle1"
+      @receipt_handle2 = "test-receipt-handle2"
       @message1 = { "ReceiptHandle" => @receipt_handle1}
       @message2 = { "ReceiptHandle" => @receipt_handle2}
       @messages = { "Message" => [ @message1, @message2 ] }
@@ -22,10 +23,10 @@ module Propono
 
       sqs.expects(:receive_message).returns(message_response)
 
-      queueListener = QueueListener.new(@queue_url) {}
-      queueListener.stubs(sqs: sqs)
+      queue_listener = QueueListener.new(@topic_id) {}
+      queue_listener.stubs(sqs: sqs)
 
-      queueListener.send(:read_messages)
+      queue_listener.send(:read_messages)
     end
 
     def test_each_message_yielded
@@ -37,10 +38,10 @@ module Propono
       sqs.expects(:delete_message).with(@receipt_handle1)
       sqs.expects(:delete_message).with(@receipt_handle2)
 
-      queueListener = QueueListener.new(@queue_url) { }
-      queueListener.stubs(sqs: sqs)
+      queue_listener = QueueListener.new(@topic_id) { }
+      queue_listener.stubs(sqs: sqs)
 
-      queueListener.send(:read_messages)
+      queue_listener.send(:read_messages)
     end
 
     def test_each_message_deleted_from_sqs
@@ -51,10 +52,10 @@ module Propono
       sqs.stubs(receive_message: message_response)
 
       messages_yielded = [ ]
-      queueListener = QueueListener.new(@queue_url) { |m| messages_yielded.push(m) }
-      queueListener.stubs(sqs: sqs)
+      queue_listener = QueueListener.new(@topic_id) { |m| messages_yielded.push(m) }
+      queue_listener.stubs(sqs: sqs)
 
-      queueListener.send(:read_messages)
+      queue_listener.send(:read_messages)
 
       assert_equal messages_yielded.size, 2
       assert messages_yielded.include?(@message1)
@@ -70,29 +71,51 @@ module Propono
 
       sqs.expects(:receive_message).returns(message_response)
 
-      queueListener = QueueListener.new(@queue_url) {}
-      queueListener.stubs(sqs: sqs)
+      queue_listener = QueueListener.new(@topic_id) {}
+      queue_listener.stubs(sqs: sqs)
 
-      refute queueListener.send(:read_messages)
+      refute queue_listener.send(:read_messages)
     end
 
     def test_exception_from_sqs_is_logged
       sqs = mock()
       sqs.stubs(:receive_message).raises(StandardError)
 
-      queueListener = QueueListener.new(@queue_url) {}
-      queueListener.stubs(sqs: sqs)
+      queue_listener = QueueListener.new(@topic_id) {}
+      queue_listener.stubs(sqs: sqs)
+      queue_listener.stubs(queue_url: "http://example.com")
 
       # capture_io reasigns stderr. Assign the config.logger
       # to where capture_io has redirected it to for this test.
       out, err = capture_io do
         config.logger = $stderr
-        queueListener.send(:read_messages)
+        queue_listener.send(:read_messages)
       end
       # Reassign config.logger to the correct stderr
       config.logger = $stderr
       assert_equal "Unexpected error reading from queue http://example.com\n", err
     end
 
+    def test_exception_from_sqs_returns_false
+      sqs = mock()
+      sqs.stubs(:receive_message).raises(StandardError)
+
+      queue_listener = QueueListener.new(@topic_id) {}
+      queue_listener.stubs(sqs: sqs)
+
+      refute queue_listener.send(:read_messages)
+    end
+
+    def test_listen_should_loop
+      listener = QueueListener.new(@topic_id)
+      listener.expects(:loop)
+      listener.listen
+    end
+
+    def test_read_messages_should_subscribe
+      listener = QueueListener.new(@topic_id)
+      QueueSubscription.expects(create: mock(queue: mock(url: {})))
+      listener.send(:read_messages)
+    end
   end
 end

--- a/test/subscriber_test.rb
+++ b/test/subscriber_test.rb
@@ -4,16 +4,16 @@ module Propono
   class SubscriberTest < Minitest::Test
 
     def test_subscribe_by_queue_calls_queue_subscriber
-      subscriber = QueueSubscriber.new("topic")
-      QueueSubscriber.expects(:new).with("topic").returns(subscriber)
-      QueueSubscriber.any_instance.expects(:subscribe)
+      subscriber = QueueSubscription.new("topic")
+      QueueSubscription.expects(:new).with("topic").returns(subscriber)
+      QueueSubscription.any_instance.expects(:create)
       Subscriber.subscribe_by_queue("topic")
     end
 
     def test_subscribe_by_post_calls_post_subscribe
-      subscriber = PostSubscriber.new("topic", 'endpoint')
-      PostSubscriber.expects(:new).with("topic", 'endpoint').returns(subscriber)
-      PostSubscriber.any_instance.expects(:subscribe)
+      subscriber = PostSubscription.new("topic", 'endpoint')
+      PostSubscription.expects(:new).with("topic", 'endpoint').returns(subscriber)
+      PostSubscription.any_instance.expects(:create)
       Subscriber.subscribe_by_post("topic", "endpoint")
     end
 


### PR DESCRIPTION
The main change here is that `QueueListener` now expects a `topic_id`, not a `queue_url`. It then generates the queue_url by calling subscribe. As part of this, it became useful to have a subscription object, that we could call `queue.url`, etc on, so I took the `QueueSubscriber` and changed it to `QueueSubscription`. I then did the same for the `PostSubscription` to match it.
