### PR TITLE
Add a CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.6.1 / 2013-10-20
+
+* [BUGFIX] Added `require 'json'` to udp_listener.rb


### PR DESCRIPTION
I've added a changelog.

I think each change we make should now append to the changelog, with an "Unreleased" date. We can then amend it when we push new releases.

I'm following the guidance from here: https://github.com/tech-angels/vandamme#changelogs-convention
