### PR TITLE
Pass an id around propono between requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.9.0 / Unreleased
+
+* [FEATURE] Add message ids that track throughout Propono
+
 # 0.8.2 / 2013-11-01
 
 * [BUGFIX] Replace thread library with standard ruby threads to fix Unicorn problems.

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ end
 
 namespace :test do
   Rake::TestTask.new(:local) do |t|
-    t.pattern = "test/{components/,services/,}*_test.rb"
+    t.pattern = "test/{components/,services/,helpers/,}*_test.rb"
   end
 end
 

--- a/lib/propono.rb
+++ b/lib/propono.rb
@@ -1,11 +1,12 @@
 # Propono
 #
 # Propono is a pub/sub gem built on top of Amazon Web Services (AWS). It uses Simple Notification Service (SNS) and Simple Queue Service (SQS) to seamlessly pass messages throughout your infrastructure.
-
 require "propono/version"
 require 'propono/propono_error'
 require 'propono/logger'
 require 'propono/configuration'
+
+require "propono/helpers/hash"
 
 require 'propono/components/sns'
 require 'propono/components/sqs'
@@ -130,8 +131,8 @@ module Propono
   # This method uses #listen_to_udp and #publish to proxy
   # messages from UDP onto the queue.
   def self.proxy_udp
-    Propono.listen_to_udp do |topic, message|
-      Propono.publish(topic, message)
+    Propono.listen_to_udp do |topic, message, options = {}|
+      Propono.publish(topic, message, options)
     end
   end
 
@@ -140,8 +141,8 @@ module Propono
   # This method uses #listen_to_tcp and #publish to proxy
   # messages from TCP onto the queue.
   def self.proxy_tcp
-    Propono.listen_to_tcp do |topic, message|
-      Propono.publish(topic, message)
+    Propono.listen_to_tcp do |topic, message, options = {}|
+      Propono.publish(topic, message, options)
     end
   end
 end

--- a/lib/propono/helpers/hash.rb
+++ b/lib/propono/helpers/hash.rb
@@ -1,0 +1,10 @@
+class Hash
+  def symbolize_keys
+    inject({}) do |result, (key, value)|
+      new_key = key.is_a?(String) ? key.to_sym : key
+      new_value = value.is_a?(Hash) ? value.symbolize_keys : value
+      result[new_key] = new_value
+      result
+    end
+  end
+end

--- a/lib/propono/services/tcp_listener.rb
+++ b/lib/propono/services/tcp_listener.rb
@@ -29,8 +29,16 @@ module Propono
     end
 
     def process_tcp_data(tcp_data)
-      json = JSON.parse(tcp_data)
-      @processor.call(json['topic'], json['message'])
+      json = JSON.parse(tcp_data).symbolize_keys
+
+      # Legacy syntax is covered in the else statement
+      # This conditional and the else block will be removed in v1.
+      if json[:id]
+        @processor.call(json[:topic], json[:message], id: json[:id])
+      else
+        Propono.config.logger.info("Sending and recieving messags without ids is deprecated")
+        @processor.call(json[:topic], json[:message])
+      end
     end
 
     def server

--- a/lib/propono/services/udp_listener.rb
+++ b/lib/propono/services/udp_listener.rb
@@ -27,8 +27,16 @@ module Propono
     end
 
     def process_udp_data(udp_data)
-      json = JSON.parse(udp_data)
-      @processor.call(json['topic'], json['message'])
+      json = JSON.parse(udp_data).symbolize_keys
+
+      # Legacy syntax is covered in the else statement
+      # This conditional and the else block will be removed in v1.
+      if json[:id]
+        @processor.call(json[:topic], json[:message], id: json[:id])
+      else
+        Propono.config.logger.info("Sending and recieving messags without ids is deprecated")
+        @processor.call(json[:topic], json[:message])
+      end
     end
 
     def socket

--- a/lib/propono/version.rb
+++ b/lib/propono/version.rb
@@ -1,3 +1,3 @@
 module Propono
-  VERSION = "0.8.2"
+  VERSION = "0.9.0"
 end

--- a/test/helpers/hash_test.rb
+++ b/test/helpers/hash_test.rb
@@ -1,0 +1,30 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+module Propono
+  class HashTest < Minitest::Test
+    def test_symbolize_keys_works
+      input = {
+        "foo" => "bar",
+        cat: 1,
+        "nest" => {
+          "dog" => [
+            {"mouse" => true}
+          ]
+        }
+      }
+      expected = {
+        foo: 'bar',
+        cat: 1,
+        nest: {
+          dog: [
+            {"mouse" => true}
+          ]
+        }
+      }
+
+      assert_equal expected, input.symbolize_keys
+    end
+  end
+end
+
+

--- a/test/integration/sns_to_sqs_test.rb
+++ b/test/integration/sns_to_sqs_test.rb
@@ -5,20 +5,29 @@ module Propono
     def test_the_message_gets_there
       topic = "test-topic"
       text = "This is my message"
+      flunks = []
 
       Propono.subscribe_by_queue(topic)
 
       thread = Thread.new do
-        Propono.listen_to_queue(topic) do |message|
-          assert_equal text, message
-          break
+        begin
+          Propono.listen_to_queue(topic) do |message, context|
+            flunks << "Wrong message" unless message == text
+            flunks << "Wrong id" unless context[:id] =~ Regexp.new("[a-z0-9]{6}")
+            break
+          end
+        rescue => e
+          flunks << e.message
+        ensure
+          thread.terminate
         end
       end
 
       sleep(2) # Make sure the listener has started
 
       Propono.publish(topic, text)
-      flunk("Test Timeout") unless wait_for_thread(thread)
+      flunks << "Test Timeout" unless wait_for_thread(thread)
+      flunk(flunks.join("\n")) unless flunks.empty?
     ensure
       thread.terminate
     end

--- a/test/integration/tcp_to_sqs_test.rb
+++ b/test/integration/tcp_to_sqs_test.rb
@@ -5,14 +5,22 @@ module Propono
     def test_the_message_gets_there
       topic = "test-topic"
       message = "This is my message"
+      flunks = []
+
       Propono.config.tcp_host = "localhost"
       Propono.config.tcp_port = 20009
 
       Propono.subscribe_by_queue(topic)
 
       sqs_thread = Thread.new do
-        Propono.listen_to_queue(topic) do |sqs_message|
-          assert_equal message, sqs_message
+        begin
+          Propono.listen_to_queue(topic) do |sqs_message|
+            flunks << "Wrong message" unless message == sqs_message
+            sqs_thread.terminate
+          end
+        rescue => e
+          flunks << e.message
+        ensure
           sqs_thread.terminate
         end
       end
@@ -26,7 +34,8 @@ module Propono
       sleep(2) # Make sure the listener has started
 
       Propono.publish(topic, message, protocol: :tcp)
-      flunk("Test Timeout") unless wait_for_thread(tcp_thread) && wait_for_thread(sqs_thread)
+      flunks << "Test Timeout" unless wait_for_thread(tcp_thread) && wait_for_thread(sqs_thread)
+      flunk(flunks.join("\n")) unless flunks.empty?
     ensure
       tcp_thread.terminate
       sqs_thread.terminate

--- a/test/integration/udp_proxy_test.rb
+++ b/test/integration/udp_proxy_test.rb
@@ -4,14 +4,23 @@ module Propono
   class UdpProxyTest < IntegrationTest
     def test_the_message_gets_there
       topic = "test-topic"
-      message = "This is my message"
+      text = "This is my message"
+      flunks = []
+
       Propono.config.udp_port = 20001
 
       Propono.subscribe_by_queue(topic)
 
       sqs_thread = Thread.new do
-        Propono.listen_to_queue(topic) do |sqs_message|
-          assert_equal message, sqs_message
+        begin
+          Propono.listen_to_queue(topic) do |message, context|
+            flunks << "Wrong message" unless text == message
+            flunks << "Wrong id" unless context[:id] =~ Regexp.new("[a-z0-9]{6}-[a-z0-9]{6}")
+            break
+          end
+        rescue => e
+          flunks << e.message
+        ensure
           sqs_thread.terminate
         end
       end
@@ -22,8 +31,9 @@ module Propono
 
       sleep(2) # Make sure the proxy has started
 
-      Propono.publish(topic, message, protocol: :udp)
-      flunk("Test timeout") unless wait_for_thread(sqs_thread)
+      Propono::Publisher.publish(topic, text, protocol: :udp)
+      flunks << "Test timeout" unless wait_for_thread(sqs_thread)
+      flunk(flunks.join("\n")) unless flunks.empty?
     ensure
       udp_thread.terminate
       sqs_thread.terminate

--- a/test/integration/udp_to_sqs_test.rb
+++ b/test/integration/udp_to_sqs_test.rb
@@ -5,13 +5,21 @@ module Propono
     def test_the_message_gets_there
       topic = "test-topic"
       message = "This is my message"
+      flunks = []
+
       Propono.config.udp_port = 20002
 
       Propono.subscribe_by_queue(topic)
 
       sqs_thread = Thread.new do
-        Propono.listen_to_queue(topic) do |sqs_message|
-          assert_equal message, sqs_message
+        begin
+          Propono.listen_to_queue(topic) do |sqs_message|
+            assert_equal message, sqs_message
+            sqs_thread.terminate
+          end
+        rescue => e
+          flunks << e.message
+        ensure
           sqs_thread.terminate
         end
       end
@@ -26,7 +34,8 @@ module Propono
       sleep(2) # Make sure the listener has started
 
       Propono.publish(topic, message, protocol: :udp)
-      flunk("Test Timeout") unless wait_for_thread(udp_thread) && wait_for_thread(sqs_thread)
+      flunks << "Test Timeout" unless wait_for_thread(udp_thread) && wait_for_thread(sqs_thread)
+      flunk(flunks.join("\n")) unless flunks.empty?
     ensure
       udp_thread.terminate
       sqs_thread.terminate

--- a/test/propono_test.rb
+++ b/test/propono_test.rb
@@ -45,8 +45,9 @@ module Propono
     def test_proxy_udp_calls_publish_in_the_block
       topic = "foobar"
       message = "message"
-      Propono.stubs(:listen_to_udp).yields(topic, message)
-      Publisher.expects(:publish).with(topic, message, {})
+      options = {id: "catdog"}
+      Propono.stubs(:listen_to_udp).yields(topic, message, options)
+      Publisher.expects(:publish).with(topic, message, options)
       Propono.proxy_udp
     end
 
@@ -58,8 +59,9 @@ module Propono
     def test_proxy_tcp_calls_publish_in_the_block
       topic = "foobar"
       message = "message"
-      Propono.stubs(:listen_to_tcp).yields(topic, message)
-      Publisher.expects(:publish).with(topic, message, {})
+      options = {id: "catdog"}
+      Propono.stubs(:listen_to_tcp).yields(topic, message, options)
+      Publisher.expects(:publish).with(topic, message, options)
       Propono.proxy_tcp
     end
   end

--- a/test/services/tcp_listener_test.rb
+++ b/test/services/tcp_listener_test.rb
@@ -45,9 +45,10 @@ module Propono
     def test_processor_is_called_correctly
       topic = "my-topic"
       message = "my-message"
+      id = "qwe123"
       processor = Proc.new {}
-      tcp_data = {topic: topic, message: message}.to_json
-      processor.expects(:call).with(topic, message)
+      tcp_data = {topic: topic, message: message, id: id}.to_json
+      processor.expects(:call).with(topic, message, {id: id})
 
       listener = TcpListener.new(&processor)
       listener.send(:process_tcp_data, tcp_data)
@@ -59,5 +60,17 @@ module Propono
       listener.listen
     end
   end
-end
 
+  class TcpListenerLegacyTest < Minitest::Test
+    def test_processor_is_called_correctly
+      topic = "my-topic"
+      message = "my-message"
+      processor = Proc.new {}
+      tcp_data = {topic: topic, message: message}.to_json
+      processor.expects(:call).with(topic, message)
+
+      listener = TcpListener.new(&processor)
+      listener.send(:process_tcp_data, tcp_data)
+    end
+  end
+end

--- a/test/services/udp_listener_test.rb
+++ b/test/services/udp_listener_test.rb
@@ -42,9 +42,10 @@ module Propono
     def test_processor_is_called_correctly
       topic = "my-topic"
       message = "my-message"
+      id = "123asd"
       processor = Proc.new {}
-      udp_data = {topic: topic, message: message}.to_json
-      processor.expects(:call).with(topic, message)
+      udp_data = {topic: topic, message: message, id: id}.to_json
+      processor.expects(:call).with(topic, message, {id: id})
 
       server = UdpListener.new(&processor)
       server.send(:process_udp_data, udp_data)
@@ -54,6 +55,19 @@ module Propono
       listener = UdpListener.new {}
       listener.expects(:loop)
       listener.listen
+    end
+  end
+
+  class UdpListenerLegacyTest < Minitest::Test
+    def test_processor_is_called_correctly
+      topic = "my-topic"
+      message = "my-message"
+      processor = Proc.new {}
+      udp_data = {topic: topic, message: message}.to_json
+      processor.expects(:call).with(topic, message)
+
+      server = UdpListener.new(&processor)
+      server.send(:process_udp_data, udp_data)
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,6 +22,7 @@ class Minitest::Test
       config.application_name = "MyApp"
 
       config.logger.stubs(:debug)
+      config.logger.stubs(:info)
       config.logger.stubs(:error)
     end
   end


### PR DESCRIPTION
This turned out to be quite complex, partially because I've tried to maintain the old syntax as well as the new, so everything doesn't suddenly break. I've written it in a way that will let us pass more propono-specific fields around very easily should we want to.

I'd like to do one more refactor on this with regards to the way we don't use DI where we could, but then I'd like to release version 1 (with the legacy stuff I worked on tonight removed).

Let me know what you think (cc @malcyl, @mmmmmrob, @ccare). Open to modifications/suggestions. I apologise if I've missed anything stupid. Tiredness is finally starting to catch up with me. Night!
