### PR TITLE
Fix error with passing two arguments to Logger#error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.1.1 / 2014-02-22
+* [BUGFIX] Logger.error only takes (0..1) arguments.
+
 # 1.1.0 / 2014-02-18
 * [FEATURE] Added slow queue to allow processing of lower priority messages.
 

--- a/lib/propono/services/queue_listener.rb
+++ b/lib/propono/services/queue_listener.rb
@@ -41,7 +41,8 @@ module Propono
       raise $!
     rescue
       Propono.config.logger.error "Unexpected error reading from queue #{queue_url}"
-      Propono.config.logger.error $!, $!.backtrace
+      Propono.config.logger.error $!
+      Propono.config.logger.error $!.backtrace
     end
 
     # The calls to delete_message are deliberately duplicated so

--- a/lib/propono/version.rb
+++ b/lib/propono/version.rb
@@ -1,3 +1,3 @@
 module Propono
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end


### PR DESCRIPTION
Passing two arguments to Logger#error is not supported.
