### PR TITLE
Add Propono.drain_queue

### DIFF
--- a/lib/propono.rb
+++ b/lib/propono.rb
@@ -107,6 +107,22 @@ module Propono
     QueueListener.listen(topic, &message_processor)
   end
 
+  # Listens on a queue and yields for each message
+  #
+  # Calling this will enter a queue-listening loop that
+  # yields the message_processor for each messages.  The
+  # loop will end when all messages have been processed.
+  #
+  # This method will automatically create a subscription if
+  # one does not exist, so there is no need to call
+  # <tt>subscribe_by_queue</tt> in addition.
+  #
+  # @param [String] topic The topic to subscribe to.
+  # @param &message_processor The block to yield for each message.
+  def self.drain_queue(topic, &message_processor)
+    QueueListener.drain(topic, &message_processor)
+  end
+
   # Listens for UDP messages and yields for each.
   #
   # Calling this will enter a queue-listening loop that

--- a/lib/propono/services/queue_listener.rb
+++ b/lib/propono/services/queue_listener.rb
@@ -7,6 +7,10 @@ module Propono
       new(topic_id, &message_processor).listen
     end
 
+    def self.drain(topic_id, &message_processor)
+      new(topic_id, &message_processor).drain
+    end
+
     def initialize(topic_id, &message_processor)
       @topic_id = topic_id
       @message_processor = message_processor
@@ -18,6 +22,13 @@ module Propono
         unless read_messages
           sleep 10
         end
+      end
+    end
+
+    def drain
+      raise ProponoError.new("topic_id is nil") unless @topic_id
+      while read_messages
+        # continue as long as there are messages in the queue
       end
     end
 

--- a/test/propono_test.rb
+++ b/test/propono_test.rb
@@ -36,6 +36,12 @@ module Propono
       Propono.listen_to_queue(topic)
     end
 
+    def test_drain_queue_calls_queue_listener
+      topic = 'foobar'
+      QueueListener.expects(:drain).with(topic)
+      Propono.drain_queue(topic)
+    end
+
     def test_listen_to_udp_calls_udp_listener
       UdpListener.expects(:listen).with()
       Propono.listen_to_udp()

--- a/test/services/queue_listener_test.rb
+++ b/test/services/queue_listener_test.rb
@@ -41,6 +41,19 @@ module Propono
       end
     end
 
+    def test_drain_should_continue_if_queue_empty
+      @listener.expects(:read_messages).returns(nil)
+      @listener.drain
+      assert true
+    end
+
+    def test_drain_raises_with_nil_topic
+      listener = QueueListener.new(nil) {}
+      assert_raises ProponoError do
+        listener.drain
+      end
+    end
+
     def test_read_messages_should_subscribe
       QueueSubscription.expects(create: mock(queue: mock(url: {})))
       @listener.send(:read_messages)


### PR DESCRIPTION
We want to have a scheduler run periodically and drain the queue - since the listen method never exits, I added drain which processes all messages, then exits
