### PR TITLE
Tighten SQS policy to only allow valid SNS topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.2.0 / 2014-05-25
+* [BUGFIX] Restrict SQS policy to only allow SNS topic publishes.
+
 # 1.1.3 / 2014-05-14
 * [FEATURE] Added ability to drain queue. Also allow dot releases of Fog.
 

--- a/lib/propono/version.rb
+++ b/lib/propono/version.rb
@@ -1,3 +1,3 @@
 module Propono
-  VERSION = "1.1.3"
+  VERSION = "1.2.0"
 end

--- a/test/integration/slow_queue_test.rb
+++ b/test/integration/slow_queue_test.rb
@@ -3,8 +3,8 @@ require File.expand_path('../integration_test', __FILE__)
 module Propono
   class SlowQueueTest < IntegrationTest
     def test_slow_messages_are_received
-      topic = "slow-test-topic"
-      slow_topic = "slow-test-topic-slow"
+      topic = "propono-tests-slow-queue-topic"
+      slow_topic = "propono-tests-slow-queue-topic-slow"
       text = "This is my message #{DateTime.now} #{rand()}"
       slow_text = "This is my slow message #{DateTime.now} #{rand()}"
       flunks = []
@@ -42,6 +42,6 @@ module Propono
       flunk(flunks.join("\n")) unless flunks.empty?
     ensure
       # thread.terminate
-    end        
+    end
   end
 end

--- a/test/integration/sns_to_sqs_test.rb
+++ b/test/integration/sns_to_sqs_test.rb
@@ -3,7 +3,7 @@ require File.expand_path('../integration_test', __FILE__)
 module Propono
   class SnsToSqsTest < IntegrationTest
     def test_the_message_gets_there
-      topic = "test-topic"
+      topic = "propono-tests-sns-to-sqs-topic"
       text = "This is my message #{DateTime.now} #{rand()}"
       flunks = []
       message_received = false
@@ -38,18 +38,18 @@ module Propono
     ensure
       thread.terminate
     end
-    
+
 =begin
-    
+
 
     def test_failed_messge_is_transferred_to_failed_channel
       topic = "test-topic"
       text = "This is my message #{DateTime.now} #{rand()}"
       flunks = []
       message_received = false
-    
+
       Propono.subscribe_by_queue(topic)
-    
+
       thread = Thread.new do
         begin
           Propono.listen_to_queue(topic) do |message, context|
@@ -61,7 +61,7 @@ module Propono
           thread.terminate
         end
       end
-      
+
       failure_listener = Thread.new do
         begin
           Propono.listen_to_queue(topic, channel: :failed) do |message, context|
@@ -75,16 +75,16 @@ module Propono
           thread.terminate
         end
       end
-    
+
       Thread.new do
         sleep(1) while !message_received
         sleep(5) # Make sure all the message deletion clear up in the thread has happened
         thread.terminate
         failure_listener.terminate
       end
-    
+
       sleep(1) # Make sure the listener has started
-    
+
       Propono.publish(topic, text)
       flunks << "Test Timeout" unless wait_for_thread(thread)
       flunk(flunks.join("\n")) unless flunks.empty?
@@ -93,6 +93,6 @@ module Propono
     end
 
 =end
-    
+
   end
 end

--- a/test/integration/tcp_to_sqs_test.rb
+++ b/test/integration/tcp_to_sqs_test.rb
@@ -1,9 +1,9 @@
 require File.expand_path('../integration_test', __FILE__)
 
 module Propono
-  class UdpToSqsTest < IntegrationTest
+  class TcpToSqsTest < IntegrationTest
     def test_the_message_gets_there
-      topic = "test-topic"
+      topic = "propono-tests-tcp-to-sqs-topic"
       message = "This is my message #{DateTime.now} #{rand()}"
       flunks = []
       message_received = false

--- a/test/integration/udp_proxy_test.rb
+++ b/test/integration/udp_proxy_test.rb
@@ -3,7 +3,7 @@ require File.expand_path('../integration_test', __FILE__)
 module Propono
   class UdpProxyTest < IntegrationTest
     def test_the_message_gets_there
-      topic = "test-topic"
+      topic = "propono-tests-udp-proxy-topic"
       text = "This is my message #{DateTime.now} #{rand()}"
       flunks = []
       message_received = false

--- a/test/integration/udp_to_sqs_test.rb
+++ b/test/integration/udp_to_sqs_test.rb
@@ -3,7 +3,7 @@ require File.expand_path('../integration_test', __FILE__)
 module Propono
   class UdpToSqsTest < IntegrationTest
     def test_the_message_gets_there
-      topic = "test-topic"
+      topic = "propono-tests-udp-to-sqs-topic"
       message = "This is my message #{DateTime.now} #{rand()}"
       flunks = []
       message_received = false


### PR DESCRIPTION
The old SQS policy allowed anyone to publish to an SQS topic. This tightens this and only lets the associated SNS topic publish to it.
