### PR TITLE
Add {async: false} option to publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.3.0 / 2014-07-12
+* [FEATURE] Add {async: false} option to publisher
+
 # 1.2.0 / 2014-05-25
 * [BUGFIX] Restrict SQS policy to only allow SNS topic publishes.
 

--- a/lib/propono/version.rb
+++ b/lib/propono/version.rb
@@ -1,3 +1,3 @@
 module Propono
-  VERSION = "1.2.0"
+  VERSION = "1.3.0"
 end

--- a/test/integration/slow_queue_test.rb
+++ b/test/integration/slow_queue_test.rb
@@ -36,8 +36,8 @@ module Propono
 
       sleep(1) # Make sure the listener has started
 
-      Propono.publish(slow_topic, slow_text)
-      Propono.publish(topic, text)
+      Propono.publish(slow_topic, slow_text, async: false)
+      Propono.publish(topic, text, async: false)
       flunks << "Test Timeout" unless wait_for_thread(thread)
       flunk(flunks.join("\n")) unless flunks.empty?
     ensure

--- a/test/integration/tcp_to_sqs_test.rb
+++ b/test/integration/tcp_to_sqs_test.rb
@@ -35,7 +35,7 @@ module Propono
 
       tcp_thread = Thread.new do
         Propono.listen_to_tcp do |tcp_topic, tcp_message|
-          Propono.publish(tcp_topic, tcp_message)
+          Propono.publish(tcp_topic, tcp_message, async: false)
           tcp_thread.terminate
         end
       end

--- a/test/services/publisher_test.rb
+++ b/test/services/publisher_test.rb
@@ -223,5 +223,17 @@ module Propono
       end
     end
 
+    def test_publish_can_be_called_syncronously
+      publisher = Publisher.new("topic_id", "message", async: false)
+      publisher.expects(:publish_via_sns_syncronously).once
+      publisher.expects(:publish_via_sns_asyncronously).never
+      publisher.send(:publish_via_sns)
+    end
+
+    def test_publish_is_normally_called_asyncronously
+      publisher = Publisher.new("topic_id", "message")
+      publisher.expects(:publish_via_sns_asyncronously)
+      publisher.send(:publish_via_sns)
+    end
   end
 end

--- a/test/services/queue_listener_test.rb
+++ b/test/services/queue_listener_test.rb
@@ -25,7 +25,7 @@ module Propono
 
       @listener = QueueListener.new(@topic_id) {}
       @listener.stubs(sqs: @sqs)
-      
+
       Propono.config.max_retries = 0
     end
 
@@ -157,7 +157,7 @@ module Propono
       @listener.stubs(:requeue_message_on_failure).with(SqsMessage.new(@sqs_message2), exception)
       @listener.send(:read_messages_from_queue, queue_url, 10)
     end
-    
+
     def test_messages_are_retried_or_abandoned_on_failure
       queue_url = "test-queue-url"
 
@@ -198,7 +198,7 @@ module Propono
       @sqs.expects(:send_message).with(regexp_matches(/https:\/\/queue.amazonaws.com\/[0-9]+\/MyApp-some-topic-failed/), anything)
       @listener.send(:requeue_message_on_failure, SqsMessage.new(@sqs_message1), StandardError.new)
     end
-    
+
     def test_message_requeued_if_there_is_an_exception_but_failure_count_less_than_retry_count
       Propono.config.max_retries = 5
       message = SqsMessage.new(@sqs_message1)
@@ -206,7 +206,7 @@ module Propono
       @sqs.expects(:send_message).with(regexp_matches(/https:\/\/queue.amazonaws.com\/[0-9]+\/MyApp-some-topic$/), anything)
       @listener.send(:requeue_message_on_failure, message, StandardError.new)
     end
-    
+
     def test_message_requeued_if_there_is_an_exception_but_failure_count_exceeds_than_retry_count
       Propono.config.max_retries = 5
       message = SqsMessage.new(@sqs_message1)


### PR DESCRIPTION
Allow messages to be published syncronously. Useful for rake tasks where `Thread.join` is a hassle!
