### PR TITLE
Change default value of 'async' for main Thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.3.1 / 2014-07-12
+* [FEATURE] Changing default behaviour of 'async' mode for single threaded apps (like Rake tasks and command-line utilities)
+
 # 1.3.0 / 2014-07-12
 * [FEATURE] Add {async: false} option to publisher
 

--- a/lib/propono/services/publisher.rb
+++ b/lib/propono/services/publisher.rb
@@ -24,7 +24,7 @@ module Propono
       @protocol = options.fetch(:protocol, :sns).to_sym
       @id = SecureRandom.hex(3)
       @id = "#{options[:id]}-#{@id}" if options[:id]
-      @async = options.fetch(:async, true)
+      @async = options.fetch(:async, Thread.main != Thread.current)
     end
 
     def publish

--- a/lib/propono/version.rb
+++ b/lib/propono/version.rb
@@ -1,3 +1,3 @@
 module Propono
-  VERSION = "1.3.0"
+  VERSION = "1.3.1"
 end


### PR DESCRIPTION
Previously Propono.publish defaulted to 'async' mode unless a specific override
was made in the configuration hash. This is a great default for a webserver,
where publishing messages out-of-band is really important, but a frustrating
default when using Propono from a single-thread app. In that scenario, the main
application thread often exits before the messages have been sent

A better solution would probably to have a countdown-latch or similar guard on
Propono, but this helps make things cleaner for using Propono in a Rake task.
