### PR TITLE
Update Meducation Team URL and member URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,14 +169,14 @@ We'd love to have you involved. Please read our [contributing guide](https://git
 
 ### Contributors
 
-This project is managed by the [Meducation team](http://company.meducation.net/about#team). 
+This project is managed by the [Meducation team](https://company.meducation.net/team). 
 
 These individuals have come up with the ideas and written the code that made this possible:
 
-- [Jeremy Walker](http://github.com/iHiD)
-- [Malcolm Landon](http://github.com/malcyL)
-- [Charles Care](http://github.com/ccare)
-- [Rob Styles](http://github.com/mmmmmrob)
+- [Jeremy Walker](https://github.com/iHiD)
+- [Malcolm Landon](https://github.com/malcyL)
+- [Charles Care](https://github.com/ccare)
+- [Rob Styles](https://github.com/mmmmmrob)
 
 ## Licence
 


### PR DESCRIPTION
Meducation team URL was a 404.

Made team member GitHub URLs https, since GitHub auto-redirects to HTTPS now, anyway. Made team URL HTTPS, as well, since meducation.net seems to also force HTTPS.