### PR TITLE
Fix mis-naming of Propono::Client#listen as #listen_to_queue in docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It's beautifully simple to use. [Watch an introduction](https://www.youtube.com/
 
 ```ruby
 # On Machine A
-Propono::Client.new.listen_to_queue('some-topic') do |message|
+Propono::Client.new.listen('some-topic') do |message|
   puts "I just received: #{message}"
 end
 
@@ -68,7 +68,7 @@ Listening for messages is easy too. Just tell Propono what your application is c
 ```ruby
 client = Propono::Client.new
 client.config.application_name = "application-name" # Something unique to this app.
-client.listen_to_queue('some-topic') do |message|
+client.listen('some-topic') do |message|
   # ... Do something interesting with the message
 end
 ```

--- a/lib/propono/components/client.rb
+++ b/lib/propono/components/client.rb
@@ -51,7 +51,7 @@ module Propono
 
     # Creates a new SNS-SQS subscription on the specified topic.
     #
-    # This is implicitly called by {#listen_to_queue}.
+    # This is implicitly called by {#listen}.
     #
     # @param [String] topic The name of the topic to subscribe to.
     def subscribe(topic)


### PR DESCRIPTION
Method name has been changed, docs have not. Updated in README and the client class.