### PR TITLE
Silence ruby warnings

### DIFF
--- a/lib/propono/logger.rb
+++ b/lib/propono/logger.rb
@@ -6,13 +6,13 @@ module Propono
 
     StdLevels.each do |level|
       define_method level do |*args|
-        $stdout.puts *args
+        $stdout.puts(*args)
       end
     end
 
     ErrorLevels.each do |level|
       define_method level do |*args|
-        $stderr.puts *args 
+        $stderr.puts(*args)
       end
     end
   end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -45,6 +45,11 @@ module Propono
       assert_equal application_name, propono_config.application_name
     end
 
+    def test_logger
+      propono_config.logger = :my_logger
+      assert_equal :my_logger, propono_config.logger
+    end
+
     def test_queue_suffix
       queue_suffix = "test-application-name"
       propono_config.queue_suffix = queue_suffix

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -64,6 +64,10 @@ module Propono
       assert_equal queue_suffix, propono_config.queue_suffix
     end
 
+    def test_default_num_messages_per_poll
+      assert_equal 10, propono_config.num_messages_per_poll
+    end
+
     def test_num_messages_per_poll
       val = 3
       propono_config.num_messages_per_poll = val

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -105,6 +105,13 @@ module Propono
       end
     end
 
+    def test_missing_max_retries_throws_exception
+      propono_config.max_retries = nil
+      assert_raises(ProponoConfigurationError) do
+        propono_config.max_retries
+      end
+    end
+
     def test_default_max_retries
       assert_equal 0, propono_config.max_retries
     end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -98,6 +98,13 @@ module Propono
       end
     end
 
+    def test_missing_logger_throws_exception
+      propono_config.logger = nil
+      assert_raises(ProponoConfigurationError) do
+        propono_config.logger
+      end
+    end
+
     def test_default_max_retries
       assert_equal 0, propono_config.max_retries
     end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -112,6 +112,13 @@ module Propono
       end
     end
 
+    def test_missing_num_messages_per_poll_throws_exception
+      propono_config.num_messages_per_poll = nil
+      assert_raises(ProponoConfigurationError) do
+        propono_config.num_messages_per_poll
+      end
+    end
+
     def test_default_max_retries
       assert_equal 0, propono_config.max_retries
     end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -45,6 +45,10 @@ module Propono
       assert_equal application_name, propono_config.application_name
     end
 
+    def test_default_logger
+      assert propono_config.logger.is_a?(Propono::Logger)
+    end
+
     def test_logger
       propono_config.logger = :my_logger
       assert_equal :my_logger, propono_config.logger

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -54,6 +54,10 @@ module Propono
       assert_equal :my_logger, propono_config.logger
     end
 
+    def test_default_queue_suffix
+      assert_equal "", propono_config.queue_suffix
+    end
+
     def test_queue_suffix
       queue_suffix = "test-application-name"
       propono_config.queue_suffix = queue_suffix

--- a/test/services/publisher_test.rb
+++ b/test/services/publisher_test.rb
@@ -115,12 +115,6 @@ module Propono
       end
     end
 
-    def test_publish_should_raise_exception_if_topic_is_nil
-      assert_raises(PublisherError, "Topic is nil") do
-        Publisher.publish(aws_client, propono_config, nil, "foobar")
-      end
-    end
-
     def test_publish_should_raise_exception_if_message_is_nil
       assert_raises(PublisherError, "Message is nil") do
         Publisher.publish(aws_client, propono_config, "foobar", nil)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,28 +14,23 @@ class Minitest::Test
   end
 
   def propono_config
-    return @propono_config if @propono_config
+    @propono_config ||= Propono::Configuration.new.tap do |c|
+      c.access_key = "test-access-key"
+      c.secret_key = "test-secret-key"
+      c.queue_region = "us-east-1"
+      c.application_name = "MyApp"
+      c.queue_suffix = ""
 
-    @propono_config = Propono::Configuration.new
-    @propono_config.access_key = "test-access-key"
-    @propono_config.secret_key = "test-secret-key"
-    @propono_config.queue_region = "us-east-1"
-    @propono_config.application_name = "MyApp"
-    @propono_config.queue_suffix = ""
-
-    @propono_config.logger.stubs(:debug)
-    @propono_config.logger.stubs(:info)
-    @propono_config.logger.stubs(:error)
-
-    @propono_config
+      c.logger.stubs(:debug)
+      c.logger.stubs(:info)
+      c.logger.stubs(:error)
+    end
   end
 
   def aws_client
-    return @aws_client if @aws_client
-
-    @aws_client = Propono::AwsClient.new(mock)
-    @aws_client.stubs(:sns_client)
-    @aws_client.stubs(:sqs_client)
-    @aws_client
+    @aws_client ||= Propono::AwsClient.new(mock).tap do |c|
+      c.stubs(:sns_client)
+      c.stubs(:sqs_client)
+    end
   end
 end


### PR DESCRIPTION
Before:

    $ rake 2>&1 | grep warning | grep propono | wc -l
    104

After:

    $ rake 2>&1 | grep warning | grep propono | wc -l
    0

Includes extra tests added to `configuration_test.rb` to make sure that the refactored configuration class is as expected.

Note: The rewritten Configuration class makes use of keyword arguments internally, and thus is only compatible with Ruby 2+.

Unless Amazon will accept a PR to remove the warnings in their `aws-sdk` and `seahorse` gems, then perhaps it might serve well to turn off warnings for the `rake test` task. Test output is still messy despite removing propono's own warnings.
