### PR TITLE
Explicit uppercase symbol use in SQS attributes

### DIFF
--- a/lib/propono/components/aws_client.rb
+++ b/lib/propono/components/aws_client.rb
@@ -43,7 +43,7 @@ module Propono
     def set_sqs_policy(queue, policy)
       sqs_client.set_queue_attributes(
         queue_url: queue.url,
-        attributes: { "Policy": policy }
+        attributes: { Policy: policy }
       )
     end
 


### PR DESCRIPTION
Hey Jeremy & Co.,

I was having troubles with plugging propono into one of my client's apps that run under Ruby 2.1. 

It was due to escaping a symbol that start with an upper case letter with quotes. Unfortunately support for this was added in Ruby 2.2, and I ended up using my fork that fixes that. 
```ruby
# This was found in your code and it causes a SyntaxError in Ruby <2.2
{ "Policy": policy }
# This is accepted in all modern Rubies and keeps the code compatible
{ "Policy".to_sym => policy }
{ Policy: policy }
```
I chose the latter. I'm not sure how you guys feel about it, but maybe you could merge it in? 

Cheers,
Kamil

