### PR TITLE
Handle use_iam_profile with the new aws-sdk gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.rbc
 .bundle
 .config
+.ruby-version
 .yardoc
 Gemfile.lock
 InstalledFiles

--- a/lib/propono/components/aws_config.rb
+++ b/lib/propono/components/aws_config.rb
@@ -9,9 +9,9 @@ module Propono
       if @config.use_iam_profile
         options = {
           :region => @config.queue_region,
-          :retries => @config.iam_profile_credentials_retries || 0,
-          :http_open_timeout => @config.iam_profile_credentials_timeout || 1,
-          :http_read_timeout => @config.iam_profile_credentials_timeout || 1
+          :retries => @config.iam_profile_credentials_retries || 5,
+          :http_open_timeout => @config.iam_profile_credentials_timeout || 5,
+          :http_read_timeout => @config.iam_profile_credentials_timeout || 5
         }
 
         { :credentials => Aws::InstanceProfileCredentials.new(options) }

--- a/lib/propono/components/aws_config.rb
+++ b/lib/propono/components/aws_config.rb
@@ -7,9 +7,14 @@ module Propono
 
     def aws_options
       if @config.use_iam_profile
-        {
-          :region => @config.queue_region
+        options = {
+          :region => @config.queue_region,
+          :retries => @config.iam_profile_credentials_retries || 0,
+          :http_open_timeout => @config.iam_profile_credentials_timeout || 1,
+          :http_read_timeout => @config.iam_profile_credentials_timeout || 1
         }
+
+        { :credentials => Aws::InstanceProfileCredentials.new(options) }
       else
         {
           :access_key_id => @config.access_key,

--- a/lib/propono/components/aws_config.rb
+++ b/lib/propono/components/aws_config.rb
@@ -8,7 +8,6 @@ module Propono
     def aws_options
       if @config.use_iam_profile
         {
-          :use_iam_profile => true,
           :region => @config.queue_region
         }
       else

--- a/lib/propono/configuration.rb
+++ b/lib/propono/configuration.rb
@@ -26,7 +26,6 @@ module Propono
     add_setting :use_iam_profile, required: false
     add_setting :iam_profile_credentials_retries, required: false
     add_setting :iam_profile_credentials_timeout, required: false
-    add_setting :iam_profile_credentials_timeout, required: false
 
     add_setting :queue_suffix,    required: false
 

--- a/lib/propono/configuration.rb
+++ b/lib/propono/configuration.rb
@@ -24,6 +24,10 @@ module Propono
     add_setting :num_messages_per_poll
 
     add_setting :use_iam_profile, required: false
+    add_setting :iam_profile_credentials_retries, required: false
+    add_setting :iam_profile_credentials_timeout, required: false
+    add_setting :iam_profile_credentials_timeout, required: false
+
     add_setting :queue_suffix,    required: false
 
     def initialize

--- a/lib/propono/version.rb
+++ b/lib/propono/version.rb
@@ -1,3 +1,3 @@
 module Propono
-  VERSION = "2.1.1"
+  VERSION = "2.1.2"
 end

--- a/lib/propono/version.rb
+++ b/lib/propono/version.rb
@@ -1,3 +1,3 @@
 module Propono
-  VERSION = "2.1.0"
+  VERSION = "2.1.1"
 end

--- a/test/components/aws_config_test.rb
+++ b/test/components/aws_config_test.rb
@@ -30,24 +30,24 @@ module Propono
       assert ! @aws_config.aws_options.has_key?(:use_iam_profile)
     end
 
-    def test_use_iam_profile
+    def test_using_iam_profile_results_in_aws_instance_profile_credentials_default
       @config.use_iam_profile = true
-      assert @aws_config.aws_options[:use_iam_profile]
+      aws_credentials = @aws_config.aws_options[:credentials]
+
+      assert_equal 5, aws_credentials.instance_variable_get("@retries")
+      assert_equal 5, aws_credentials.instance_variable_get("@http_open_timeout")
+      assert_equal 5, aws_credentials.instance_variable_get("@http_read_timeout")
     end
 
-    def test_selecting_use_iam_profile_results_in_no_access_key
+    def test_using_iam_profile_results_in_aws_instance_profile_credentials
       @config.use_iam_profile = true
-      assert ! @aws_config.aws_options.has_key?(:access_key_id)
-    end
+      @config.iam_profile_credentials_retries = 3
+      @config.iam_profile_credentials_timeout = 4
+      aws_credentials = @aws_config.aws_options[:credentials]
 
-    def test_selecting_use_iam_profile_results_in_no_secret_key
-      @config.use_iam_profile = true
-      assert ! @aws_config.aws_options.has_key?(:secret_access_key)
-    end
-
-    def test_region_when_using_iam_profile
-      @config.use_iam_profile = true
-      assert_equal "test-queue-region", @aws_config.aws_options[:region]
+      assert_equal 3, aws_credentials.instance_variable_get("@retries")
+      assert_equal 4, aws_credentials.instance_variable_get("@http_open_timeout")
+      assert_equal 4, aws_credentials.instance_variable_get("@http_read_timeout")
     end
   end
 end


### PR DESCRIPTION
The aws-sdk Gem now suggests that you create an instance Aws::InstanceProfileCredentials object when setting the credentials.