### PR TITLE
[WIP] Simplest implementation of multi-threaded listener w. configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Propono::Client.new do |config|
 
   config.max_retries = "The number of retries if a message raises an exception before being placed on the failed queue"
   config.num_messages_per_poll = "The number of messages retrieved per poll to SQS"
+  config.listener_worker_count = "The number of threads a listener should process messages with. Default is 1."
 end
 ```
 

--- a/lib/propono/configuration.rb
+++ b/lib/propono/configuration.rb
@@ -22,6 +22,7 @@ module Propono
     add_setting :logger
     add_setting :max_retries
     add_setting :num_messages_per_poll
+    add_setting :listener_worker_count
 
     add_setting :use_iam_profile, required: false
     add_setting :queue_suffix,    required: false
@@ -32,7 +33,8 @@ module Propono
         queue_suffix:          "",
         use_iam_profile:       false,
         max_retries:           0,
-        num_messages_per_poll: 10
+        num_messages_per_poll: 10,
+        listener_worker_count: 1
       }
     end
 

--- a/lib/propono/services/queue_listener.rb
+++ b/lib/propono/services/queue_listener.rb
@@ -20,9 +20,18 @@ module Propono
 
     def listen
       raise ProponoError.new("topic_name is nil") unless topic_name
-      loop do
-        read_messages
+
+      threads = []
+
+      propono_config.listener_worker_count.times do
+        threads << Thread.new do
+          loop do
+            read_messages
+          end
+        end
       end
+
+      threads.each(&:join)
     end
 
     def drain


### PR DESCRIPTION
This is the simplest implementation of a multi-threaded Propono listener that works, using a group of threads in a manager/worker arrangement.

By default there is only a single worker thread. This will cause no changes to be required for existing applications.

Worker thread counts can be controller using the `listener_worker_count` config.

It would likely be better to expand on this implementation, making it more like the Sidekiq Manager and Processor, with handling of interrupts, graceful shutdown, that sort of thing.

Tested with the following in the root directory of a Propono checkout:

```
$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), 'lib'))

require 'propono'

client                              = Propono::Client.new
client.config.access_key            = ""
client.config.secret_key            = ""
client.config.queue_region          = "eu-west-1"
client.config.application_name      = 'listener-1'
client.config.listener_worker_count = 2

TOPIC = 'threaded-listener-topic'.freeze

20.times do
  client.publish(TOPIC, { multiply: 12 })
end

client.listen(TOPIC) do |message|
  puts "#{Thread.current.object_id} just received: #{message.inspect}"
  sleep 1
end
```