### PR TITLE
Default to 1 for num_messages_per_poll.

### DIFF
--- a/lib/propono/configuration.rb
+++ b/lib/propono/configuration.rb
@@ -32,7 +32,7 @@ module Propono
         queue_suffix:          "",
         use_iam_profile:       false,
         max_retries:           0,
-        num_messages_per_poll: 10
+        num_messages_per_poll: 1
       }
     end
 

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -65,7 +65,7 @@ module Propono
     end
 
     def test_default_num_messages_per_poll
-      assert_equal 10, propono_config.num_messages_per_poll
+      assert_equal 1, propono_config.num_messages_per_poll
     end
 
     def test_num_messages_per_poll


### PR DESCRIPTION
The previous default of 10 made sense as a default before the listener was re-written to use long-polling. With long-polling the next job in the queue will be fetched instantly, so no need to queue up multiple messages locally.