### PR TITLE
Allow configuration of SNS and SQS endpoints.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ Propono::Client.new do |config|
 
   config.max_retries = "The number of retries if a message raises an exception before being placed on the failed queue"
   config.num_messages_per_poll = "The number of messages retrieved per poll to SQS"
+
+  config.sns_endpoint = "The SNS endpoint to use. Useful for testing against non-AWS endpoints. Defined as scheme://host:port."
+  config.sns_endpoint = "The SQS endpoint to use. Useful for testing against non-AWS endpoints. Defined as scheme://host:port."
 end
 ```
 

--- a/lib/propono/components/aws_client.rb
+++ b/lib/propono/components/aws_client.rb
@@ -68,11 +68,11 @@ module Propono
     private
 
     def sns_client
-      @sns_client ||= Aws::SNS::Client.new(aws_config.aws_options)
+      @sns_client ||= Aws::SNS::Client.new(aws_config.sns_options)
     end
 
     def sqs_client
-      @sqs_client ||= Aws::SQS::Client.new(aws_config.aws_options)
+      @sqs_client ||= Aws::SQS::Client.new(aws_config.sqs_options)
     end
   end
 end

--- a/lib/propono/components/aws_config.rb
+++ b/lib/propono/components/aws_config.rb
@@ -5,18 +5,34 @@ module Propono
       @config = config
     end
 
-    def aws_options
+    def sns_options
+      options_with_endpoint_or_region(@config.sns_endpoint)
+    end
+
+    def sqs_options
+      options_with_endpoint_or_region(@config.sqs_endpoint)
+    end
+
+    private
+
+    def base_options
       if @config.use_iam_profile
         {
-          :use_iam_profile => true,
-          :region => @config.queue_region
+          use_iam_profile: true
         }
       else
         {
-          :access_key_id => @config.access_key,
-          :secret_access_key => @config.secret_key,
-          :region => @config.queue_region
+          access_key_id:     @config.access_key,
+          secret_access_key: @config.secret_key
         }
+      end
+    end
+
+    def options_with_endpoint_or_region(endpoint)
+      if endpoint
+        base_options.merge({ endpoint: endpoint })
+      else
+        base_options.merge({ region: @config.queue_region })
       end
     end
   end

--- a/lib/propono/configuration.rb
+++ b/lib/propono/configuration.rb
@@ -25,6 +25,8 @@ module Propono
 
     add_setting :use_iam_profile, required: false
     add_setting :queue_suffix,    required: false
+    add_setting :sqs_endpoint,    required: false
+    add_setting :sns_endpoint,    required: false
 
     def initialize
       @settings = {

--- a/test/components/aws_config_test.rb
+++ b/test/components/aws_config_test.rb
@@ -14,40 +14,101 @@ module Propono
       @aws_config = Propono::AwsConfig.new(@config)
     end
 
-    def test_access_key
-      assert_equal "test-access-key", @aws_config.aws_options[:access_key_id]
+    def test_sns_options_access_key
+      assert_equal "test-access-key", @aws_config.sns_options[:access_key_id]
     end
 
-    def test_secret_key
-      assert_equal "test-secret-key", @aws_config.aws_options[:secret_access_key]
+    def test_sns_options_secret_key
+      assert_equal "test-secret-key", @aws_config.sns_options[:secret_access_key]
     end
 
-    def test_region
-      assert_equal "test-queue-region", @aws_config.aws_options[:region]
+    def test_sns_options_region
+      assert_equal "test-queue-region", @aws_config.sns_options[:region]
     end
 
-    def test_no_iam_profile_selected
-      assert ! @aws_config.aws_options.has_key?(:use_iam_profile)
+    def test_sns_options_no_iam_profile_selected
+      assert ! @aws_config.sns_options.has_key?(:use_iam_profile)
     end
 
-    def test_use_iam_profile
+    def test_sns_options_use_iam_profile
       @config.use_iam_profile = true
-      assert @aws_config.aws_options[:use_iam_profile]
+      assert @aws_config.sns_options[:use_iam_profile]
     end
 
-    def test_selecting_use_iam_profile_results_in_no_access_key
+    def test_sns_options_selecting_use_iam_profile_results_in_no_access_key
       @config.use_iam_profile = true
-      assert ! @aws_config.aws_options.has_key?(:access_key_id)
+      assert ! @aws_config.sns_options.has_key?(:access_key_id)
     end
 
-    def test_selecting_use_iam_profile_results_in_no_secret_key
+    def test_sns_options_selecting_use_iam_profile_results_in_no_secret_key
       @config.use_iam_profile = true
-      assert ! @aws_config.aws_options.has_key?(:secret_access_key)
+      assert ! @aws_config.sns_options.has_key?(:secret_access_key)
     end
 
-    def test_region_when_using_iam_profile
+    def test_sns_options_region_when_using_iam_profile
       @config.use_iam_profile = true
-      assert_equal "test-queue-region", @aws_config.aws_options[:region]
+      assert_equal "test-queue-region", @aws_config.sns_options[:region]
     end
+
+    def test_sns_options_endpoint_when_no_endpoint_specified
+      assert_nil   @aws_config.sns_options[:endpoint]
+      assert_equal "test-queue-region", @aws_config.sns_options[:region]
+    end
+
+    def test_sns_options_endpoint_when_endpoint_specified
+      @config.sns_endpoint = "http://my.endpoint:3333"
+
+      assert_equal "http://my.endpoint:3333", @aws_config.sns_options[:endpoint]
+      assert_nil   @aws_config.sns_options[:region]
+    end
+
+    def test_sqs_options_access_key
+      assert_equal "test-access-key", @aws_config.sqs_options[:access_key_id]
+    end
+
+    def test_sqs_options_secret_key
+      assert_equal "test-secret-key", @aws_config.sqs_options[:secret_access_key]
+    end
+
+    def test_sqs_options_region
+      assert_equal "test-queue-region", @aws_config.sqs_options[:region]
+    end
+
+    def test_sqs_options_no_iam_profile_selected
+      assert ! @aws_config.sqs_options.has_key?(:use_iam_profile)
+    end
+
+    def test_sqs_options_use_iam_profile
+      @config.use_iam_profile = true
+      assert @aws_config.sqs_options[:use_iam_profile]
+    end
+
+    def test_sqs_options_selecting_use_iam_profile_results_in_no_access_key
+      @config.use_iam_profile = true
+      assert ! @aws_config.sqs_options.has_key?(:access_key_id)
+    end
+
+    def test_sqs_options_selecting_use_iam_profile_results_in_no_secret_key
+      @config.use_iam_profile = true
+      assert ! @aws_config.sqs_options.has_key?(:secret_access_key)
+    end
+
+    def test_sqs_options_region_when_using_iam_profile
+      @config.use_iam_profile = true
+      assert_equal "test-queue-region", @aws_config.sqs_options[:region]
+    end
+
+    def test_sqs_options_endpoint_when_no_endpoint_specified
+      assert_nil   @aws_config.sqs_options[:endpoint]
+      assert_equal "test-queue-region", @aws_config.sqs_options[:region]
+    end
+
+    def test_sqs_options_endpoint_when_endpoint_specified
+      @config.sqs_endpoint = "http://my.endpoint:3333"
+
+      assert_equal "http://my.endpoint:3333", @aws_config.sqs_options[:endpoint]
+      assert_nil   @aws_config.sqs_options[:region]
+    end
+
   end
 end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -21,6 +21,24 @@ module Propono
       assert propono_config.use_iam_profile
     end
 
+    def test_sqs_endpoint_defaults_false
+      assert ! propono_config.sqs_endpoint
+    end
+
+    def test_sqs_endpoint
+      propono_config.sqs_endpoint = true
+      assert propono_config.sqs_endpoint
+    end
+
+    def test_sns_endpoint_defaults_false
+      assert ! propono_config.sns_endpoint
+    end
+
+    def test_sns_endpoint
+      propono_config.sns_endpoint = true
+      assert propono_config.sns_endpoint
+    end
+
     def test_access_key
       access_key = "test-access-key"
       propono_config.access_key = access_key


### PR DESCRIPTION
When either endpoint is included in SQS, region is ignored.

Fixes #84.