### PR TITLE
Add option to break listen loop after a set period of idleness.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,24 @@ end
 
 These can all also be set using the `client.config.access_key = "..."` syntax.
 
+#### Idle Timeout
+
+In some situations, it is useful to exit the listen work loop after a set period if no messages have been received. An example would be to allow idle job processing servers to terminate themselves safely if they have not done any work for a set period of time.
+
+This can be achieved by passing `visibility_timeout` with a value in seconds to `listen`. e.g.
+
+```
+client.listen('tasks', idle_timeout: 60 * 10) do |message|
+  puts "I just received: #{message}"
+end
+
+puts "listen loop terminated after 10 minutes of idleness"
+```
+
+After 10 minutes of the listen loop not receiving any messages, it will exit, and any following code will be executed.
+
+Default is `nil`, with the listen loop never timing out through ideleness.
+
 ### Is it any good?
 
 [Yes.](http://news.ycombinator.com/item?id=3067434)

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ puts "listen loop terminated after 10 minutes of idleness"
 
 After 10 minutes of the listen loop not receiving any messages, it will exit, and any following code will be executed.
 
-Default is `nil`, with the listen loop never timing out through ideleness.
+Default is `nil`, with the listen loop never timing out through idleness.
 
 ### Is it any good?
 

--- a/lib/propono/services/queue_listener.rb
+++ b/lib/propono/services/queue_listener.rb
@@ -133,12 +133,16 @@ module Propono
         return false
       end
 
-      time_idle = Time.now.to_i - @last_message_read_at
+      time_idle = Time.now.to_i - last_message_read_at
       time_idle >= idle_timeout
     end
 
     def reset_idle_timeout!
       @last_message_read_at = Time.now.to_i
+    end
+
+    def last_message_read_at
+      @last_message_read_at
     end
   end
 end

--- a/lib/propono/services/queue_listener.rb
+++ b/lib/propono/services/queue_listener.rb
@@ -130,7 +130,7 @@ module Propono
 
     def idle_timeout_reached?
       if idle_timeout.nil?
-        false
+        return false
       end
 
       time_idle = Time.now.to_i - @last_message_read_at

--- a/lib/propono/services/queue_listener.rb
+++ b/lib/propono/services/queue_listener.rb
@@ -25,9 +25,7 @@ module Propono
       reset_idle_timeout!
 
       loop do
-        if idle_timeout_reached?
-          break
-        end
+        break if idle_timeout_reached?
         read_messages
       end
     end

--- a/test/services/queue_listener_test.rb
+++ b/test/services/queue_listener_test.rb
@@ -244,7 +244,7 @@ module Propono
     def test_idle_timeout_exits_loop
       timeout = 1
 
-      aws_client.stubs(read_from_sqs: [])
+      aws_client.expects(read_from_sqs: []).once
       @listener = QueueListener.new(aws_client, propono_config, @topic_name, idle_timeout: timeout) { |msg| p msg }
 
       @time = Time.now.to_i


### PR DESCRIPTION
In some situations, it is useful to exit the listen work loop after a set period if no messages have been received. An example would be to allow idle job processing servers to terminate themselves safely if they have not done any work for a set period of time.

With this PR this can be achieved by passing `visibility_timeout` with a value in seconds to `listen`. e.g.

```
client.listen('tasks', idle_timeout: 60 * 10) do |message|
  puts "I just received: #{message}"
end

puts "listen loop terminated after 10 minutes of idleness"
```

After 10 minutes of the listen loop not receiving any messages, it will exit, and any following code will be executed.

Default is `nil`, with the listen loop never timing out through idleness.

