### PR TITLE
Proposal: Improved AWS configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.0.0 / 2021-01-10
+* [FEATURE] Improve AWS configuration.
+
 # 2.2.0 / 2019-09-21
 * [FEATURE] Add setting to disable slow queue
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ To manually configure options for use with AWS, use `aws_options`, which sets op
 
     client = Propono::Client.new do |config|
       config.aws_options = {
-        region:            'aws_region'
+        region:            'aws_region',
         access_key_id:     'your_access_key_id',
         secret_access_key: 'your_secret_access_key'        
       }

--- a/README.md
+++ b/README.md
@@ -21,13 +21,9 @@ Propono::Client.new.publish('some-topic', "The Best Message Ever")
 # - "I just received The Best Message Ever"
 ```
 
-## Changes from v1 to v2
+## Upgrading
 
-Version 2 of Propono changed a few things:
-- We moved from a global interface to a client interface. Rather than calling `publish` and equivalent on `Propono`, you should now initialize a `Propono::Client` and then call everything on that client. This fixes issues with thread safety and global config.
-- We have also removed the dependancy on Fog and instead switch to the `sns` and `sqs` mini-gems of `aws-sdk`.
-- UDP and TCP support have been removed, and `subscribe_by_post` has been removed.
-- We are now using long-polling. This makes Propono **significantly** faster (10-100x).
+Upgrading from v1 to v2, and v2 to v3 are covered in the [upgrade documentation](docs/upgrading.md).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -41,18 +41,12 @@ And then execute:
 
 ## Usage
 
-The first thing to do is setup some configuration keys for Propono. It's best to do this in an initializer, or at the start of your application.
+The first thing to do is setup some configuration for Propono.
+It's best to do this in an initializer, or at the start of your application.
+If you need to setup AWS authentication, see the [AWS Configuration](#aws-configuration) section.
 
 ```ruby
 client = Propono::Client.new
-client.config.access_key       = "access-key"       # From AWS
-client.config.secret_key       = "secret-key"       # From AWS
-client.config.queue_region     = "queue-region"     # From AWS
-
-# Or use the IAM profile of the machine
-client.config.use_iam_profile  = true
-client.config.queue_region     = "queue-region"     # From AWS
-
 ```
 
 You can then start publishing messages easily from anywhere in your codebase.
@@ -81,19 +75,35 @@ This is because a queue is established for each application_name/topic combinati
 * subscribers that share the same `application_name` will act as multiple workers on the same queue. Only one will get to process each message.
 * subscribers that have a different `application_name` will each get a copy of a message to process independently i.e. acts as a one-to-many broadcast.
 
-### Configuration
+### AWS Configuration
 
-The following configuration settings are available:
+By default, Propono will create SQS and SNS clients with no options.
+In the absense of options, these clients will make use of the credentials on the current host.
+See the [AWS SDK For Ruby Configuration documentation](https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/setup-config.html) for more details.
+
+To manually configure options for use with AWS, use `aws_options`, which sets options to be passed to both clients. For example:
+
+    client = Propono::Client.new do |config|
+      config.aws_options = {
+        region:            'aws_region'
+        access_key_id:     'your_access_key_id',
+        secret_access_key: 'your_secret_access_key'        
+      }
+    end
+
+In addition to this, there is also `sqs_options` and `sns_options`, used to configure each client independently.
+See the [SQS Client](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/SQS/Client.html#initialize-instance_method) and [SNS Client](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/SNS/Client.html#initialize-instance_method) documentation for available options.
+These individual options are merged with `aws_options` with the per-client options taking precendence.
+
+### General configuration
 
 ```
 Propono::Client.new do |config|
-  # Use AWS access and secret keys
-  config.access_key = "An AWS access key"
-  config.secret_key = "A AWS secret key"
-  # Or use AWS IAM profile of the machine
-  config.use_iam_profile = true
+  # AWS Configuration, see above.
+  config.aws_options = {...}
+  config.sqs_options = {...}
+  config.sns_options = {...}
 
-  config.queue_region = "An AWS queue region"
   config.application_name = "A name unique in your network"
   config.logger = "A logger such as Log4r or Rails.logger"
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This is because a queue is established for each application_name/topic combinati
 ### AWS Configuration
 
 By default, Propono will create SQS and SNS clients with no options.
-In the absense of options, these clients will make use of the credentials on the current host.
+In the absence of options, these clients will make use of the credentials on the current host.
 See the [AWS SDK For Ruby Configuration documentation](https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/setup-config.html) for more details.
 
 To manually configure options for use with AWS, use `aws_options`, which sets options to be passed to both clients. For example:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Propono::Client.new.publish('some-topic', "The Best Message Ever")
 
 ## Upgrading
 
-Upgrading from v1 to v2, and v2 to v3 are covered in the [upgrade documentation](docs/upgrading.md).
+Upgrades from v1 to v2, and v2 to v3 are covered in the [upgrade documentation](docs/upgrading.md).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ In addition to this, there is also `sqs_options` and `sns_options`, used to conf
 See the [SQS Client](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/SQS/Client.html#initialize-instance_method) and [SNS Client](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/SNS/Client.html#initialize-instance_method) documentation for available options.
 These individual options are merged with `aws_options` with the per-client options taking precendence.
 
-### General configuration
+### General Configuration
 
 ```
 Propono::Client.new do |config|

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -7,7 +7,7 @@ passed to the client gems. Instead of Propono attempting to guess which
 configuration options you might want, it now accepts hashes for AWS
 configuration which are passed directly to the appropriate clients.
 
-If you are upgrading from v1 to v2, and using the configuration as previously
+If you are upgrading from v2 to v3, and using the configuration as previously
 given in the README, you need to change from:
 
 ```ruby

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -12,9 +12,9 @@ given in the README, you need to change from:
 
 ```ruby
 client = Propono::Client.new
-client.config.queue_region = "aws_region"
-client.config.access_key   = "your_access_key_id"
-client.config.secret_key   = "your_secret_access_key"
+client.config.queue_region = 'aws_region'
+client.config.access_key   = 'your_access_key_id'
+client.config.secret_key   = 'your_secret_access_key'
 ```
 
 To:
@@ -22,7 +22,7 @@ To:
 ```ruby
 client = Propono::Client.new do |config|
   config.aws_options = {
-    region:            'aws_region'
+    region:            'aws_region',
     access_key_id:     'your_access_key_id',
     secret_access_key: 'your_secret_access_key'
   }

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -12,9 +12,9 @@ given in the README, you need to change from:
 
 ```ruby
 client = Propono::Client.new
-client.config.access_key       = "your_access_key_id"       # From AWS
-client.config.secret_key       = "your_secret_access_key"       # From AWS
-client.config.queue_region     = "aws_regiou"     # From AWS
+client.config.access_key   = "your_access_key_id"
+client.config.secret_key   = "your_secret_access_key"
+client.config.queue_region = "aws_region"
 ```
 
 To:
@@ -24,7 +24,7 @@ client = Propono::Client.new do |config|
   config.aws_options = {
     region:            'aws_region'
     access_key_id:     'your_access_key_id',
-    secret_access_key: 'your_secret_access_key'        
+    secret_access_key: 'your_secret_access_key'
   }
 end
 ```
@@ -46,4 +46,3 @@ Version 2 of Propono changed a few things:
   removed.
 - We are now using long-polling. This makes Propono **significantly** faster
   (10-100x).
-

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,0 +1,49 @@
+# Upgrading
+
+## Changes from v2 to v3
+
+Version 3 changed the way configuration options for the two AWS services are
+passed to the client gems. Instead of Propono attempting to guess which
+configuration options you might want, it now accepts hashes for AWS
+configuration which are passed directly to the appropriate clients.
+
+If you are upgrading from v1 to v2, and using the configuration as previously
+given in the README, you need to change from:
+
+```ruby
+client = Propono::Client.new
+client.config.access_key       = "your_access_key_id"       # From AWS
+client.config.secret_key       = "your_secret_access_key"       # From AWS
+client.config.queue_region     = "aws_regiou"     # From AWS
+```
+
+To:
+
+```ruby
+client = Propono::Client.new do |config|
+  config.aws_options = {
+    region:            'aws_region'
+    access_key_id:     'your_access_key_id',
+    secret_access_key: 'your_secret_access_key'        
+  }
+end
+```
+
+For a full rundown, see the [AWS Configuration
+section](../README.md#aws-configuration) of the README.
+
+
+## Changes from v1 to v2
+
+Version 2 of Propono changed a few things:
+- We moved from a global interface to a client interface. Rather than calling
+  `publish` and equivalent on `Propono`, you should now initialize a
+  `Propono::Client` and then call everything on that client. This fixes issues
+  with thread safety and global config.
+- We have also removed the dependancy on Fog and instead switch to the `sns`
+  and `sqs` mini-gems of `aws-sdk`.
+- UDP and TCP support have been removed, and `subscribe_by_post` has been
+  removed.
+- We are now using long-polling. This makes Propono **significantly** faster
+  (10-100x).
+

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -12,9 +12,9 @@ given in the README, you need to change from:
 
 ```ruby
 client = Propono::Client.new
+client.config.queue_region = "aws_region"
 client.config.access_key   = "your_access_key_id"
 client.config.secret_key   = "your_secret_access_key"
-client.config.queue_region = "aws_region"
 ```
 
 To:

--- a/lib/propono/components/aws_client.rb
+++ b/lib/propono/components/aws_client.rb
@@ -68,11 +68,11 @@ module Propono
     private
 
     def sns_client
-      @sns_client ||= Aws::SNS::Client.new(aws_config.aws_options)
+      @sns_client ||= Aws::SNS::Client.new(aws_config.sns_options)
     end
 
     def sqs_client
-      @sqs_client ||= Aws::SQS::Client.new(aws_config.aws_options)
+      @sqs_client ||= Aws::SQS::Client.new(aws_config.sqs_options)
     end
   end
 end

--- a/lib/propono/components/aws_config.rb
+++ b/lib/propono/components/aws_config.rb
@@ -5,19 +5,13 @@ module Propono
       @config = config
     end
 
-    def aws_options
-      if @config.use_iam_profile
-        {
-          :use_iam_profile => true,
-          :region => @config.queue_region
-        }
-      else
-        {
-          :access_key_id => @config.access_key,
-          :secret_access_key => @config.secret_key,
-          :region => @config.queue_region
-        }
-      end
+    def sqs_options
+      @config.aws_options.merge(@config.sqs_options)
     end
+
+    def sns_options
+      @config.aws_options.merge(@config.sns_options)
+    end
+
   end
 end

--- a/lib/propono/components/client.rb
+++ b/lib/propono/components/client.rb
@@ -1,23 +1,28 @@
 module Propono
   class Client
 
-    # Propono configuration settings.
+    # Propono configuration.
     #
     # Settings should be set in an initializer or using some
-    # other method that insures they are set before any
-    # Propono code is used. They can be set as followed:
+    # other method that ensures they are set before any
+    # Propono code is used.
     #
-    #   Propono.config.access_key = "my-access-key"
+    # They can be set in one of the following ways:
     #
-    # The following settings are allowed:
+    # 1. As options passed to <tt>new</tt> as a hash.
     #
-    # * <tt>:access_key</tt> - The AWS access key
-    # * <tt>:secret_key</tt> - The AWS secret key
-    # * <tt>:queue_region</tt> - The AWS region
-    # * <tt>:application_name</tt> - The name of the application Propono
-    #   is included in.
-    # * <tt>:queue_suffix</tt> - Optional string to append to topic and queue names.
-    # * <tt>:logger</tt> - A logger object that responds to puts.
+    #   Propono::Client.new(application_name: 'my-application')
+    #
+    # 2. As options passed to <tt>new</tt> using a block.
+    #
+    #   Propono::Client.new do |config"
+    #     config.application_name: 'my-application'
+    #   end
+    #   
+    # 3. By calling the <tt>Propono::Client#configure</tt>.
+    #   client.configure do |config|
+    #     config.access_key = "my-access-key"
+    #   end
 
     attr_reader :config, :aws_client
     def initialize(settings = {}, &block)

--- a/lib/propono/configuration.rb
+++ b/lib/propono/configuration.rb
@@ -15,23 +15,23 @@ module Propono
       end
     end
 
-    add_setting :access_key
-    add_setting :secret_key
-    add_setting :queue_region
+    add_setting :aws_options
+    add_setting :sqs_options
+    add_setting :sns_options
     add_setting :application_name
     add_setting :logger
     add_setting :max_retries
     add_setting :num_messages_per_poll
     add_setting :slow_queue_enabled, required: false
-
-    add_setting :use_iam_profile, required: false
-    add_setting :queue_suffix,    required: false
+    add_setting :queue_suffix, required: false
 
     def initialize
       @settings = {
+        aws_options:           {},
+        sqs_options:           {},
+        sns_options:           {},
         logger:                Propono::Logger.new,
         queue_suffix:          "",
-        use_iam_profile:       false,
         max_retries:           0,
         num_messages_per_poll: 1,
         slow_queue_enabled:    true

--- a/lib/propono/version.rb
+++ b/lib/propono/version.rb
@@ -1,3 +1,3 @@
 module Propono
-  VERSION = "2.2.1"
+  VERSION = "3.0.0"
 end

--- a/test/components/aws_config_test.rb
+++ b/test/components/aws_config_test.rb
@@ -7,47 +7,27 @@ module Propono
       super
       @config = Propono::Configuration.new
 
-      @config.access_key = "test-access-key"
-      @config.secret_key = "test-secret-key"
-      @config.queue_region = "test-queue-region"
+      @config.aws_options = { a: 'any', b: 'aws-specific' }
+      @config.sqs_options = { a: 'sqs', c: 'sqs-specific' }
+      @config.sns_options = { a: 'sns', c: 'sns-specific' }
 
       @aws_config = Propono::AwsConfig.new(@config)
     end
 
-    def test_access_key
-      assert_equal "test-access-key", @aws_config.aws_options[:access_key_id]
+    def test_overwritten_keys_take_precendence
+      assert_equal 'sqs', @aws_config.sqs_options[:a]
+      assert_equal 'sns', @aws_config.sns_options[:a]
     end
 
-    def test_secret_key
-      assert_equal "test-secret-key", @aws_config.aws_options[:secret_access_key]
+    def test_common_keys_remain
+      assert_equal 'aws-specific', @aws_config.sqs_options[:b]
+      assert_equal 'aws-specific', @aws_config.sns_options[:b]
     end
 
-    def test_region
-      assert_equal "test-queue-region", @aws_config.aws_options[:region]
+    def test_specific_keys_remain
+      assert_equal 'sqs-specific', @aws_config.sqs_options[:c]
+      assert_equal 'sns-specific', @aws_config.sns_options[:c]
     end
 
-    def test_no_iam_profile_selected
-      assert ! @aws_config.aws_options.has_key?(:use_iam_profile)
-    end
-
-    def test_use_iam_profile
-      @config.use_iam_profile = true
-      assert @aws_config.aws_options[:use_iam_profile]
-    end
-
-    def test_selecting_use_iam_profile_results_in_no_access_key
-      @config.use_iam_profile = true
-      assert ! @aws_config.aws_options.has_key?(:access_key_id)
-    end
-
-    def test_selecting_use_iam_profile_results_in_no_secret_key
-      @config.use_iam_profile = true
-      assert ! @aws_config.aws_options.has_key?(:secret_access_key)
-    end
-
-    def test_region_when_using_iam_profile
-      @config.use_iam_profile = true
-      assert_equal "test-queue-region", @aws_config.aws_options[:region]
-    end
   end
 end

--- a/test/components/client_test.rb
+++ b/test/components/client_test.rb
@@ -75,11 +75,11 @@ module Propono
     end
 
     def test_block_configuration_syntax
-      test_key = "foobar-123-access"
+      test_application_name = "my-application"
       client = Propono::Client.new do |config|
-        config.access_key = test_key
+        config.application_name = test_application_name
       end
-      assert_equal test_key, client.config.access_key
+      assert_equal test_application_name, client.config.application_name
     end
   end
 end

--- a/test/config.yml.example
+++ b/test/config.yml.example
@@ -1,4 +1,23 @@
-access_key: test-aws-access-key
-secret_key: test-aws-secret-key
-queue_region: test-aws-region
 application_name: tests-yourinitials
+
+# Whatever keys are in aws_options are passed directly to the AWS clients.
+
+# Option 1 - Do nothing.
+# AWS clients will either use the default profile in ~/.aws/credentials, or use an IAM Role if on EC2.
+
+# Option 2 - Use environment variables
+# You can set a non-default local profile with the AWS_PROFILE environment variable.
+# You can also set keys directly: https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/setup-config.html#aws-ruby-sdk-credentials-environment
+
+# Option 3 - Set values directly.
+aws_options: 
+  # Required
+  region: 'test-aws-region'
+
+  # Set keys:
+  # access_key_id: test-aws-access-key
+  # secret_access_key: test-aws-secret-key
+
+  # Or set a profile:
+  # profile: profile-name
+

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -12,37 +12,40 @@ module Propono
       refute propono_config.nil?
     end
 
-    def test_use_iam_profile_defaults_false
-      assert ! propono_config.use_iam_profile
-    end
-
-    def test_use_iam_profile
-      propono_config.use_iam_profile = true
-      assert propono_config.use_iam_profile
-    end
-
-    def test_access_key
-      access_key = "test-access-key"
-      propono_config.access_key = access_key
-      assert_equal access_key, propono_config.access_key
-    end
-
-    def test_secret_key
-      secret_key = "test-secret-key"
-      propono_config.secret_key = secret_key
-      assert_equal secret_key, propono_config.secret_key
-    end
-
-    def test_queue_region
-      queue_region = "test-queue-region"
-      propono_config.queue_region = queue_region
-      assert_equal queue_region, propono_config.queue_region
-    end
-
     def test_application_name
       application_name = "test-application-name"
       propono_config.application_name = application_name
       assert_equal application_name, propono_config.application_name
+    end
+
+    def test_default_aws_options
+      assert_equal({}, propono_config.aws_options)
+    end
+
+    def test_aws_options
+      opts = { foo: 'bar' }
+      propono_config.aws_options = opts
+      assert_equal opts, propono_config.aws_options
+    end
+
+    def test_default_sqs_options
+      assert_equal({}, propono_config.sqs_options)
+    end
+
+    def test_sqs_options
+      opts = { foo: 'bar' }
+      propono_config.sqs_options = opts
+      assert_equal opts, propono_config.sqs_options
+    end
+
+    def test_default_sns_options
+      assert_equal({}, propono_config.sns_options)
+    end
+
+    def test_sns_options
+      opts = { foo: 'bar' }
+      propono_config.sns_options = opts
+      assert_equal opts, propono_config.sns_options
     end
 
     def test_default_logger
@@ -72,24 +75,6 @@ module Propono
       val = 3
       propono_config.num_messages_per_poll = val
       assert_equal val, propono_config.num_messages_per_poll
-    end
-
-    def test_missing_access_key_throws_exception
-      assert_raises(ProponoConfigurationError) do
-        propono_config.access_key
-      end
-    end
-
-    def test_missing_secret_key_throws_exception
-      assert_raises(ProponoConfigurationError) do
-        propono_config.secret_key
-      end
-    end
-
-    def test_missing_queue_region_throws_exception
-      assert_raises(ProponoConfigurationError) do
-        propono_config.queue_region
-      end
     end
 
     def test_missing_application_name_throws_exception

--- a/test/integration/integration_test.rb
+++ b/test/integration/integration_test.rb
@@ -6,9 +6,7 @@ module Propono
     def propono_client
       config_file = YAML.load_file( File.expand_path('../../config.yml', __FILE__))
       @propono_client ||= Propono::Client.new do |config|
-        config.access_key = config_file['access_key']
-        config.secret_key = config_file['secret_key']
-        config.queue_region = config_file['queue_region']
+        config.aws_options      = config_file['aws_options']
         config.application_name = config_file['application_name']
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,9 +15,6 @@ class Minitest::Test
 
   def propono_config
     @propono_config ||= Propono::Configuration.new.tap do |c|
-      c.access_key = "test-access-key"
-      c.secret_key = "test-secret-key"
-      c.queue_region = "us-east-1"
       c.application_name = "MyApp"
       c.queue_suffix = ""
 


### PR DESCRIPTION
# Summary

Proposed change to Propono configuration, to allow more flexible AWS configuration, and defaults which match those of the `aws-sdk`.

PR is currently a docs-only change, to encourage discussion, with code changes to follow after.

# What problems does this solve?

Currently, AWS for Propono has two authentication options:

1. Passing in keys, which requires the keys to be available to the application, or
2. IAM roles (which are broken, see #90 and #96)

Proposed changes would:

1. By default require no AWS configuration. AWS gems would use their own defaults of either credentials in `~/.aws/credentials` or an IAM Role (if on EC2, ECS, etc).
2. Add a new configuration option `aws_options`, into which any options common to both SQS and SNS could be passed. Examples of these are `region`, `access_key_id`, and `secret_access_key`.
3. Add `sqs_options` and `sns_options` to configure per-service options. An example of where separate configuration might be useful is setting endpoints for development work. See #95.
4. Allow advanced authentication methods, such as `Aws::AssumeRoleCredentials`.
5. Encourage better practice, by not requiring keys which could potentially be committed source control.

# What about existing configuration options?

Currently, Propono provides `access_key`, `secret_key`, and `queue_region`.

Short term, remove these options from documentation, and have them continue to work silently. Optionally display a deprecation notice for each usage. This would allow current users to continue to use their existing authentication setup without modification.

On release of the next major version, remove these options entirely.