### PR TITLE
Update to allow use of Ruby 3.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,13 +15,13 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        ruby-version: [2.6, 2.7, 3.0.0-preview1]
+        ruby-version: [2.6, 2.7, '3.0', 3.1]
 
     steps:
       - uses: actions/checkout@v2
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@a699edbce608a2c128dedad88e3b6a0e28687b3c
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        ruby-version: [2.6, 2.7]
+        ruby-version: [2.6, 2.7, 3.0.0-preview1]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@180e1d1f1c5eadbfbab3dab6fb79ab0c07e3cecc
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true

--- a/lib/propono/services/publisher.rb
+++ b/lib/propono/services/publisher.rb
@@ -5,8 +5,8 @@ module Propono
   end
 
   class Publisher
-    def self.publish(*args)
-      new(*args).publish
+    def self.publish(aws_client, propono_config, topic_name, message, options={})
+      new(aws_client, propono_config, topic_name, message, **options).publish
     end
 
     attr_reader :aws_client, :propono_config, :topic_name, :message, :id, :async

--- a/lib/propono/services/publisher.rb
+++ b/lib/propono/services/publisher.rb
@@ -5,8 +5,14 @@ module Propono
   end
 
   class Publisher
-    def self.publish(aws_client, propono_config, topic_name, message, options={})
-      new(aws_client, propono_config, topic_name, message, **options).publish
+    if RUBY_VERSION < '3'
+      def self.publish(*args)
+        new(*args).publish
+      end
+    else
+      def self.publish(aws_client, propono_config, topic_name, message, options = {})
+        new(aws_client, propono_config, topic_name, message, **options).publish
+      end
     end
 
     attr_reader :aws_client, :propono_config, :topic_name, :message, :id, :async

--- a/propono.gemspec
+++ b/propono.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "aws-sdk-sns"
   spec.add_dependency "aws-sdk-sqs"
+  spec.add_dependency "nokogiri"
 
   spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake"

--- a/propono.gemspec
+++ b/propono.gemspec
@@ -20,11 +20,11 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "aws-sdk-sns"
   spec.add_dependency "aws-sdk-sqs"
-  spec.add_dependency "nokogiri"
 
   spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "mocha"
+  spec.add_development_dependency "nokogiri"
   spec.add_development_dependency "yard"
   spec.add_development_dependency "minitest", "~> 5.0.8"
 end

--- a/test/services/publisher_test.rb
+++ b/test/services/publisher_test.rb
@@ -11,8 +11,8 @@ module Propono
     def test_self_publish_calls_new
       topic = "topic123"
       message = "message123"
-      Publisher.expects(:new).with(aws_client, topic, message).returns(mock(publish: nil))
-      Publisher.publish(aws_client, topic, message)
+      Publisher.expects(:new).with(aws_client, propono_config, topic, message).returns(mock(publish: nil))
+      Publisher.publish(aws_client, propono_config, topic, message)
     end
 
     def test_initializer_generates_an_id


### PR DESCRIPTION
Addresses #105 

I wasn't able to get the 3.0 syntax for the Publisher::publish() to work with ruby 2.6 although it does work with 2.7. I made my condition < 3 to ensure we didn't poke current users.

I had to include an XML parser for 3.0, happy to pull in a different one if you'd like.

I think there's a bigger P/R to change to named arguments throughout (instead of the options hash), but that's going to give you breaking changes. I'm happy to do the work, but let's open an issue so we can discuss logistics before I start throwing stuff over the wall.

